### PR TITLE
implement DaemonSets

### DIFF
--- a/victims/factory/daemonsets/daemonsets.go
+++ b/victims/factory/daemonsets/daemonsets.go
@@ -1,0 +1,63 @@
+package daemonsets
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/asobti/kube-monkey/config"
+	"github.com/asobti/kube-monkey/victims"
+
+	"k8s.io/api/apps/v1"
+)
+
+type DaemonSet struct {
+	*victims.VictimBase
+}
+
+// Create a new instance of DaemonSet
+func New(dep *v1.DaemonSet) (*DaemonSet, error) {
+	ident, err := identifier(dep)
+	if err != nil {
+		return nil, err
+	}
+	mtbf, err := meanTimeBetweenFailures(dep)
+	if err != nil {
+		return nil, err
+	}
+	kind := fmt.Sprintf("%T", *dep)
+
+	return &DaemonSet{victims.New(kind, dep.Name, dep.Namespace, ident, mtbf)}, nil
+}
+
+// Returns the value of the label defined by config.IdentLabelKey
+// from the DaemonSet labels
+// This label should be unique to a DaemonSet, and is used to
+// identify the pods that belong to this DaemonSet, as pods
+// inherit labels from the DaemonSet
+func identifier(kubekind *v1.DaemonSet) (string, error) {
+	identifier, ok := kubekind.Labels[config.IdentLabelKey]
+	if !ok {
+		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.IdentLabelKey)
+	}
+	return identifier, nil
+}
+
+// Read the mean-time-between-failures value defined by the DaemonSet
+// in the label defined by config.MtbfLabelKey
+func meanTimeBetweenFailures(kubekind *v1.DaemonSet) (int, error) {
+	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
+	if !ok {
+		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
+	}
+
+	mtbfInt, err := strconv.Atoi(mtbf)
+	if err != nil {
+		return -1, err
+	}
+
+	if !(mtbfInt > 0) {
+		return -1, fmt.Errorf("Invalid value for label %s: %d", config.MtbfLabelKey, mtbfInt)
+	}
+
+	return mtbfInt, nil
+}

--- a/victims/factory/daemonsets/daemonsets_test.go
+++ b/victims/factory/daemonsets/daemonsets_test.go
@@ -1,0 +1,92 @@
+package daemonsets
+
+import (
+	"testing"
+
+	"github.com/asobti/kube-monkey/config"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	IDENTIFIER = "kube-monkey-id"
+	NAME       = "daemonset_name"
+	NAMESPACE  = metav1.NamespaceDefault
+)
+
+func newDaemonSet(name string, labels map[string]string) v1.DaemonSet {
+
+	return v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: NAMESPACE,
+			Labels:    labels,
+		},
+	}
+}
+
+func TestNew(t *testing.T) {
+
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: IDENTIFIER,
+			config.MtbfLabelKey:  "1",
+		},
+	)
+	ds, err := New(&v1ds)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "v1.DaemonSet", ds.Kind())
+	assert.Equal(t, NAME, ds.Name())
+	assert.Equal(t, NAMESPACE, ds.Namespace())
+	assert.Equal(t, IDENTIFIER, ds.Identifier())
+	assert.Equal(t, 1, ds.Mtbf())
+}
+
+func TestInvalidIdentifier(t *testing.T) {
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.MtbfLabelKey: "1",
+		},
+	)
+	_, err := New(&v1ds)
+
+	assert.Errorf(t, err, "Expected an error if "+config.IdentLabelKey+" label doesn't exist")
+}
+
+func TestInvalidMtbf(t *testing.T) {
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: IDENTIFIER,
+		},
+	)
+	_, err := New(&v1ds)
+
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label doesn't exist")
+
+	v1ds = newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: IDENTIFIER,
+			config.MtbfLabelKey:  "string",
+		},
+	)
+	_, err = New(&v1ds)
+
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a Int type")
+
+	v1ds = newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: IDENTIFIER,
+			config.MtbfLabelKey:  "0",
+		},
+	)
+	_, err = New(&v1ds)
+
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label is lower than 1")
+}

--- a/victims/factory/daemonsets/eligible_daemonsets.go
+++ b/victims/factory/daemonsets/eligible_daemonsets.go
@@ -1,0 +1,90 @@
+package daemonsets
+
+//All these functions require api access specific to the version of the app
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/golang/glog"
+
+	"github.com/asobti/kube-monkey/config"
+	"github.com/asobti/kube-monkey/victims"
+
+	kube "k8s.io/client-go/kubernetes"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Get all eligible daemonsets that opted in (filtered by config.EnabledLabel)
+func EligibleDaemonSets(clientset kube.Interface, namespace string, filter *metav1.ListOptions) (eligVictims []victims.Victim, err error) {
+	enabledVictims, err := clientset.AppsV1().DaemonSets(namespace).List(*filter)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vic := range enabledVictims.Items {
+		victim, err := New(&vic)
+		if err != nil {
+			glog.Warningf("Skipping eligible %T %s because of error: %s", vic, vic.Name, err.Error())
+			continue
+		}
+
+		// TODO: After generating whitelisting ns list, this will move to factory.
+		// IsBlacklisted will change to something like IsAllowedNamespace
+		// and will only be used to verify at time of scheduled execution
+		if victim.IsBlacklisted() {
+			continue
+		}
+
+		eligVictims = append(eligVictims, victim)
+	}
+
+	return
+}
+
+/* Below methods are used to verify the victim's attributes have not changed at the scheduled time of termination */
+
+// Checks if the daemonset is currently enrolled in kube-monkey
+func (d *DaemonSet) IsEnrolled(clientset kube.Interface) (bool, error) {
+	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	if err != nil {
+		return false, nil
+	}
+	return daemonset.Labels[config.EnabledLabelKey] == config.EnabledLabelValue, nil
+}
+
+// Returns current killtype config label for update
+func (d *DaemonSet) KillType(clientset kube.Interface) (string, error) {
+	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	killType, ok := daemonset.Labels[config.KillTypeLabelKey]
+	if !ok {
+		return "", fmt.Errorf("%s %s does not have %s label", d.Kind(), d.Name(), config.KillTypeLabelKey)
+	}
+
+	return killType, nil
+}
+
+// Returns current killvalue config label for update
+func (d *DaemonSet) KillValue(clientset kube.Interface) (int, error) {
+	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	if err != nil {
+		return -1, err
+	}
+
+	killMode, ok := daemonset.Labels[config.KillValueLabelKey]
+	if !ok {
+		return -1, fmt.Errorf("%s %s does not have %s label", d.Kind(), d.Name(), config.KillValueLabelKey)
+	}
+
+	killModeInt, err := strconv.Atoi(killMode)
+	if !(killModeInt > 0) {
+		return -1, fmt.Errorf("Invalid value for label %s: %d", config.KillValueLabelKey, killModeInt)
+	}
+
+	return killModeInt, nil
+}

--- a/victims/factory/daemonsets/eligible_daemonsets_test.go
+++ b/victims/factory/daemonsets/eligible_daemonsets_test.go
@@ -1,0 +1,156 @@
+package daemonsets
+
+import (
+	"testing"
+
+	"github.com/asobti/kube-monkey/config"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEligibleDaemonSets(t *testing.T) {
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			"kube-monkey/identifier": "1",
+			"kube-monkey/mtbf":       "1",
+		},
+	)
+
+	client := fake.NewSimpleClientset(&v1ds)
+	victims, _ := EligibleDaemonSets(client, NAMESPACE, &metav1.ListOptions{})
+
+	assert.Len(t, victims, 1)
+}
+
+func TestIsEnrolled(t *testing.T) {
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey:   "1",
+			config.MtbfLabelKey:    "1",
+			config.EnabledLabelKey: config.EnabledLabelValue,
+		},
+	)
+
+	depl, _ := New(&v1ds)
+
+	client := fake.NewSimpleClientset(&v1ds)
+
+	b, _ := depl.IsEnrolled(client)
+
+	assert.Equal(t, b, true, "Expected daemoset to be enrolled")
+}
+
+func TestIsNotEnrolled(t *testing.T) {
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey:   "1",
+			config.MtbfLabelKey:    "1",
+			config.EnabledLabelKey: "x",
+		},
+	)
+
+	ds, _ := New(&v1ds)
+
+	client := fake.NewSimpleClientset(&v1ds)
+
+	b, _ := ds.IsEnrolled(client)
+
+	assert.Equal(t, b, false, "Expected daemonset to not be enrolled")
+}
+
+func TestKillType(t *testing.T) {
+
+	ident := "1"
+	mtbf := "1"
+	killMode := "kill-mode"
+
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: ident,
+			config.MtbfLabelKey:  mtbf,
+		},
+	)
+
+	depl, _ := New(&v1ds)
+
+	client := fake.NewSimpleClientset(&v1ds)
+
+	_, err := depl.KillType(client)
+
+	assert.EqualError(t, err, depl.Kind()+" "+depl.Name()+" does not have "+config.KillTypeLabelKey+" label")
+
+	v1ds = newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey:    ident,
+			config.MtbfLabelKey:     mtbf,
+			config.KillTypeLabelKey: killMode,
+		},
+	)
+
+	client = fake.NewSimpleClientset(&v1ds)
+
+	kill, _ := depl.KillType(client)
+
+	assert.Equal(t, kill, killMode, "Unexpected kill value, got %d", kill)
+}
+
+func TestKillValue(t *testing.T) {
+
+	ident := "1"
+	mtbf := "1"
+	killValue := "0"
+
+	v1ds := newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey: ident,
+			config.MtbfLabelKey:  mtbf,
+		},
+	)
+
+	depl, _ := New(&v1ds)
+
+	client := fake.NewSimpleClientset(&v1ds)
+
+	_, err := depl.KillValue(client)
+
+	assert.EqualError(t, err, depl.Kind()+" "+depl.Name()+" does not have "+config.KillValueLabelKey+" label")
+
+	v1ds = newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey:     ident,
+			config.MtbfLabelKey:      mtbf,
+			config.KillValueLabelKey: killValue,
+		},
+	)
+
+	client = fake.NewSimpleClientset(&v1ds)
+
+	_, err = depl.KillValue(client)
+
+	assert.EqualError(t, err, "Invalid value for label "+config.KillValueLabelKey+": "+killValue)
+
+	killValue = "1"
+
+	v1ds = newDaemonSet(
+		NAME,
+		map[string]string{
+			config.IdentLabelKey:     ident,
+			config.MtbfLabelKey:      mtbf,
+			config.KillValueLabelKey: killValue,
+		},
+	)
+
+	client = fake.NewSimpleClientset(&v1ds)
+
+	kill, _ := depl.KillValue(client)
+
+	assert.Equalf(t, kill, 1, "Unexpected a kill value, got %d", kill)
+}

--- a/victims/factory/factory.go
+++ b/victims/factory/factory.go
@@ -13,6 +13,7 @@ import (
 	"github.com/asobti/kube-monkey/victims"
 	"github.com/asobti/kube-monkey/victims/factory/deployments"
 	"github.com/asobti/kube-monkey/victims/factory/statefulsets"
+	"github.com/asobti/kube-monkey/victims/factory/daemonsets"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -54,6 +55,15 @@ func EligibleVictims() (eligibleVictims []victims.Victim, err error) {
 			continue
 		}
 		eligibleVictims = append(eligibleVictims, statefulsets...)
+
+		// Fetch daemonsets
+		daemonsets, err := daemonsets.EligibleDaemonSets(clientset, namespace, filter)
+		if err != nil {
+			//allow pass through to schedule other kinds and namespaces
+			glog.Warningf("Failed to fetch eligible daemonsets for namespace %s due to error: %s", namespace, err.Error())
+			continue
+		}
+		eligibleVictims = append(eligibleVictims, daemonsets...)
 	}
 
 	return


### PR DESCRIPTION
1.Describe what this PR did

Implement DaemonSets.

2.Does this pull request fix one issue?

It's part of #10 (https://github.com/asobti/kube-monkey/issues/10)

3.Describe how you did it

Implement DaemonSets.

4.Describe how to verify it
```
[root@k8s-master examples]# cat configmap.yaml 
---
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: kube-monkey-config-map
    namespace: kube-system
  data:
    config.toml: |
      [kubemonkey]
      run_hour = 10
      start_hour = 11
      end_hour = 12
      time_zone = "Asia/Shanghai"
      blacklisted_namespaces = ["kube-system"]
      whitelisted_namespaces = ["chaos-test"]
      [debug]
      enabled = true
      schedule_delay = 10

      
[root@k8s-master examples]# cat chaos-victim-ds.yaml 
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: chaos-victim-ds
  namespace: chaos-test
  labels:
    name: "chaos-victim-ds"
    app: "chaos-victim-ds"
    kube-monkey/enabled: "enabled"
    kube-monkey/identifier: "chaos-victim-ds"
    kube-monkey/mtbf: "2"
    kube-monkey/kill-mode: "fixed"
    kube-monkey/kill-value: "1"
spec:
  selector:
    matchLabels:
      name: "chaos-victim-ds"
  template:
    metadata:
      labels:
        name: "chaos-victim-ds"
        app: "chaos-victim-ds"
        kube-monkey/enabled: "enabled"
        kube-monkey/identifier: "chaos-victim-ds"
        kube-monkey/mtbf: "2"
        kube-monkey/kill-mode: "fixed"
        kube-monkey/kill-value: "1"
    spec:
      containers:
        -  name: chaos-victim-ds
           command:
             - sleep
             - "3600"
           image: docker.io/busybox:latest

[root@k8s-master examples]# kubectl -n kube-system get pods |grep monkey
kube-monkey-7b8987b4d8-9rmb2               1/1       Running   0          6s
[root@k8s-master examples]# kubectl -n kube-system logs -f kube-monkey-7b8987b4d8-9rmb2 
I0404 09:42:59.838484       1 config.go:74] Successfully validated configs
I0404 09:42:59.838547       1 main.go:52] Starting kube-monkey with v logging level 5 and local log directory /var/log/kube-monkey
I0404 09:42:59.927583       1 kubemonkey.go:19] Debug mode detected!
I0404 09:42:59.927632       1 kubemonkey.go:20] Status Update: Generating next schedule in 10 sec
I0404 09:43:09.928023       1 schedule.go:54] Status Update: Generating schedule for terminations
I0404 09:43:10.107131       1 schedule.go:47] Status Update: 0 terminations scheduled today
I0404 09:43:10.107311       1 kubemonkey.go:63] Status Update: Waiting to run scheduled terminations.
I0404 09:43:10.107396       1 kubemonkey.go:77] Status Update: All terminations done.
I0404 09:43:10.107626       1 kubemonkey.go:19] Debug mode detected!
I0404 09:43:10.107673       1 kubemonkey.go:20] Status Update: Generating next schedule in 10 sec
	********** Today's schedule **********
No terminations scheduled
	********** End of schedule **********
I0404 09:43:20.108099       1 schedule.go:54] Status Update: Generating schedule for terminations
	********** Today's schedule **********
	k8 Api Kind	Kind Name		Termination Time
	-----------	---------		----------------
	v1.DaemonSet	chaos-victim-ds		04/04/2018 11:49:00 +0800 CST
	********** End of schedule **********
I0404 09:43:20.129063       1 schedule.go:47] Status Update: 1 terminations scheduled today
I0404 09:43:20.129106       1 schedule.go:49] v1.DaemonSet chaos-victim-ds scheduled for termination at 04/04/2018 11:49:00 +0800 CST
I0404 09:43:20.129175       1 kubemonkey.go:63] Status Update: Waiting to run scheduled terminations.
```

5.Special notes for reviews
None